### PR TITLE
lanetix/issues#2172 Actually log errors

### DIFF
--- a/middleware/error.js
+++ b/middleware/error.js
@@ -1,0 +1,21 @@
+'use strict';
+var util = require('util');
+
+module.exports = function (app) {
+  return function (err, req, res, next) {
+    var statusCode = err.statusCode || (err.output && err.output.statusCode) || 500;
+    res.status(statusCode);
+
+    if (app.get('options').isProduction || statusCode !== 500) {
+      if (statusCode === 500) {
+        // for Papertrail purposes.
+        var errorMsg = 'Error: ' + (err.stack || util.inspect(err, { depth: null }));
+        errorMsg += req ? '\nUrl: ' + req.originalUrl + '\nBody: ' + util.inspect(req.body, { depth: null }) : '';
+        console.error(errorMsg);
+      }
+      res.json({message: err.message});
+    } else {
+      next(err);
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^0.15",
     "eslint-plugin-nodeca": "^1",
     "mocha": "^2.0.1",
-    "node-mocks-http": "^1.2.1",
+    "node-mocks-http": "^1.4.1",
     "should": "^4.3.0",
     "sinon": "^1.12.2"
   }

--- a/server.js
+++ b/server.js
@@ -64,21 +64,6 @@ module.exports = function () {
       }
 
       // error handler
-      app.use(function (err, req, res, next) {
-        var statusCode = err.statusCode || (err.output && err.output.statusCode) || 500;
-        res.status(statusCode);
-
-        if (app.get('options').isProduction || statusCode !== 500) {
-          if (statusCode === 500) {
-            // for Papertrail purposes.
-            var errorMsg = 'Error: ' + JSON.stringify(err);
-            errorMsg += req ? '\nUrl: ' + req.originalUrl + '\nBody: ' + JSON.stringify(req.body) : '';
-            console.error(errorMsg);
-          }
-          res.json({message: err.message});
-        } else {
-          next(err);
-        }
-      });
+      app.use(middleware.error(app));
     });
 };

--- a/test/middleware/error.js
+++ b/test/middleware/error.js
@@ -1,0 +1,122 @@
+'use strict';
+
+var _ = require('lodash'),
+  httpMocks = require('node-mocks-http'),
+  sinon = require('sinon'),
+  error = require('../../middleware/error');
+
+describe('middleware/error', function () {
+  var req, res;
+
+  beforeEach(function () {
+    req = httpMocks.createRequest();
+    res = httpMocks.createResponse();
+  });
+
+  describe('in production', function () {
+    var err, consoleError;
+
+    beforeEach(function () {
+      err = error({ get: _.constant({ isProduction: true }) });
+      //silence console.error
+      consoleError = console.error;
+      console.error = _.noop;
+    });
+
+    afterEach(function () {
+      console.error = consoleError;
+    });
+
+    it('should set status to 500', function () {
+      err({}, req, res, _.noop);
+      res.should.have.property('statusCode', 500);
+    });
+
+    it('should send the message', function () {
+      err(new Error('lol'), req, res, _.noop);
+
+      /* eslint-disable no-underscore-dangle */
+      var body = JSON.parse(res._getData());
+      body.should.have.property('message', 'lol');
+      /* eslint-enable no-underscore-dangle */
+    });
+
+    describe('logging', function () {
+      var sandbox;
+
+      beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+        console.error = sinon.spy();
+      });
+
+      afterEach(function () {
+        sandbox.restore();
+      });
+
+      it('should log something with a circular ref', function () {
+        var spyCall, message,
+          foo = {};
+        foo.foo = foo;
+        err(foo, req, res, _.noop);
+
+        spyCall = console.error.getCall(0);
+        message = spyCall.args[0];
+        message.should.match(/^Error: \{ foo: \[Circular\] \}/);
+      });
+
+      it('should log an error\'s stack', function () {
+        var spyCall, message;
+        err(new Error('lol'), req, res, _.noop);
+
+        spyCall = console.error.getCall(0);
+        message = spyCall.args[0];
+        message.should.match(/^Error: Error: lol\s+at /);
+      });
+
+      it('should log the url', function () {
+        var spyCall, message;
+
+        req.originalUrl = '/foo';
+
+        err({}, req, res, _.noop);
+
+        spyCall = console.error.getCall(0);
+        message = spyCall.args[0];
+        message.should.match(/Url: \/foo/);
+      });
+
+      it('should log the body', function () {
+        var spyCall, message;
+
+        req.body = { foo: 'bar' };
+
+        err({}, req, res, _.noop);
+
+        spyCall = console.error.getCall(0);
+        message = spyCall.args[0];
+        message.should.match(/Body: \{ foo: 'bar' \}/);
+      });
+
+    });
+  });
+
+  describe('not in production', function () {
+    var err;
+
+    beforeEach(function () {
+      err = error({ get: _.constant({}) });
+    });
+
+    it('should call next with the error', function () {
+      var error = {};
+      err(error, req, res, function (err) {
+        err.should.equal(error);
+      });
+    });
+
+    it('should set status to 500', function () {
+      err({}, req, res, _.noop);
+      res.should.have.property('statusCode', 500);
+    });
+  });
+});


### PR DESCRIPTION
This corrects three issues with the previous error handler implementation.

1. Actual `Error` objects weren't logged because of the way they get converted to json
2. `JSON.stringify` will fail for some valid objects (e.g. circular references). When logging, you should prefer `util.inspect`.
3. There weren't any tests :stuck_out_tongue: 