### PR TITLE
lanetix/issues#2820 exploit preflight cache

### DIFF
--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -4,7 +4,10 @@ var cors = require('cors'),
   defaultExposedHeaders = [
     'X-Total-Count'
   ],
-  corsConfig = {};
+  corsConfig = {
+    credentials: true,
+    maxAge: 10 * 60 // this is the maximum we can cache in chrome
+  };
 
 module.exports = function (app) {
   var options = app.get('options');


### PR DESCRIPTION
Use the preflight cache so we don't have to send as many options requests.