### PR TITLE
Access the jwt from the request

### DIFF
--- a/middleware/jwt.js
+++ b/middleware/jwt.js
@@ -8,6 +8,7 @@ var BPromise = require('bluebird'),
 module.exports = function (app) {
   return function (req, res, next) {
     var token = (req.get('authorization') || '').substring('Bearer '.length);
+    req.encodedJwt = token;
 
     if (!token || !token.length) {
       return res.boom.unauthorized();


### PR DESCRIPTION
This is useful when you need to send some requests to other services, using the
jwt of the originating request.