### PR TITLE
Create version 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,70 @@
 
 Wrapper for writing JWT-authenticated microservices for internal use within Lanetix.
 
+## Installation
+
+`npm install --save lanetix-microservice`
+
+## Usage
+
+Optimally, the creation of the express app should be separated out from the creation of the HTTP server for ease of testing.
+
+```
+// server.js - build up your express app
+
+import express from 'express'
+import { server } from 'lanetix-microservice'
+import fooRouter from './routers/foo'
+import bonkRouter from './routers/bonk'
+
+const app = express()
+export default server(app, {
+  postAuthentication: [
+    // middleware goes here
+  ],
+
+  routers: {
+    '/foo': fooRouter,
+    '/bonk': bonkRouter
+  }
+})
+
+// web.js - bind to a port and launch your application
+
+import { createServer } from 'http'
+import server from './server'
+
+const port = 9999
+const httpServer = createServer(server)
+httpServer.listen(port, () => {
+  console.log(`listening on port ${port}`)
+})
+```
+
+## Testing
+
+The `test` client allows you to make requests to an in-memory version of your application. GET, POST, PATCH, PUT, and DELETE are supported HTTP verbs.
+
+A user can be impersonated by providing either:
+- A `user_id` property directly on the context
+- Or a `user` property on the context that has an `id`
+
+```
+import { test } from 'lanetix-microservice'
+import server from '../server'
+
+describe('Microservice tests', () => {
+  it('should return 200 OK for a GET to /foo', () =>
+    test.serve(server, { user_id: 1337 })
+      .get('/foo')
+      .expect(200)
+  )
+
+  it('should return 201 Created for a POST to /bonk', () =>
+    test.serve(server, { user_id: 1337 })
+      .post('/bonk')
+      .send({ data: 'hello' })
+      .expect(201)
+  )
+})
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lanetix-microservice",
-  "version": "1.6.2",
+  "version": "2.0.0",
   "description": "Wrapper for writing JWT-authenticated microservices for internal use within Lanetix.",
   "author": "Lanetix <engineering@lanetix.com> (https://github.com/lanetix/)",
   "homepage": "https://github.com/lanetix/node-lanetix-microservice/",
@@ -23,7 +23,6 @@
     "boom": "^2.6.0",
     "cookie-parser": "^1.3.5",
     "cors": "^2.5.2",
-    "express": "^4.10.2",
     "express-boom": "^0.3.0",
     "jsonwebtoken": "^5.0.0",
     "lodash": "^2.4.1",

--- a/server.js
+++ b/server.js
@@ -1,17 +1,15 @@
 'use strict';
 
 var _ = require('lodash'),
-  express = require('express'),
   bodyParser = require('body-parser'),
   boom = require('express-boom'),
   config = require('./config'),
   path = require('path'),
   middleware = require('require-directory')(module, path.join(__dirname, 'middleware'));
 
-module.exports = function () {
-  var args = Array.prototype.slice.call(arguments),
-    options = _.extend.apply(_, [{}, config].concat(args)),
-    app = express();
+module.exports = function (app, options) {
+  _.extend(options, config)
+  options = _.extend(config, options)
 
   app.enable('trust proxy');
   app.disable('x-powered-by');

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('lodash'),
-  BPromise = require('bluebird'),
   express = require('express'),
   bodyParser = require('body-parser'),
   boom = require('express-boom'),
@@ -11,59 +10,53 @@ var _ = require('lodash'),
 
 module.exports = function () {
   var args = Array.prototype.slice.call(arguments),
-    options = _.extend.apply(_, [{}, config].concat(args));
+    options = _.extend.apply(_, [{}, config].concat(args)),
+    app = express();
 
-  return BPromise.resolve(express())
-    .tap(function (app) {
-      app.enable('trust proxy');
-      app.disable('x-powered-by');
-      app.set('options', options);
+  app.enable('trust proxy');
+  app.disable('x-powered-by');
+  app.set('options', options);
 
-      // configure
-      if (options.configure && _.isFunction(options.configure)) {
-        return options.configure(app);
-      }
-    })
-    .tap(function (app) {
-      app.get('/health', middleware.health);
-      app.use(bodyParser.json({limit: '5mb'}));
-      app.use(boom());
-      app.use(middleware.response(app));
-      app.use(middleware.cors(app));
+  // configure
+  if (options.configure && _.isFunction(options.configure)) {
+    return options.configure(app);
+  }
+  app.get('/health', middleware.health);
+  app.use(bodyParser.json({limit: '5mb'}));
+  app.use(boom());
+  app.use(middleware.response(app));
+  app.use(middleware.cors(app));
 
-      // pre-authentication
-      if (options.preAuthentication && _.isFunction(options.preAuthentication)) {
-        return options.preAuthentication(app);
-      } else if (options.preAuthentication && _.isArray(options.preAuthentication)) {
-        options.preAuthentication.forEach(function (fn) {
-          app.use(fn(app));
-        });
-      }
-    })
-    .tap(function (app) {
-      app.use(middleware.jwt(app));
-
-      // post-authentication
-      if (options.postAuthentication && _.isFunction(options.postAuthentication)) {
-        return options.postAuthentication(app);
-      } else if (options.postAuthentication && _.isArray(options.postAuthentication)) {
-        options.postAuthentication.forEach(function (fn) {
-          app.use(fn(app));
-        });
-      }
-    })
-    .tap(function (app) {
-      // routers
-      if (options.routers) {
-        Object.keys(options.routers).forEach(function (key) {
-          var route = options.routers[key];
-          (_.isArray(route) ? route : [route]).forEach(function (route) {
-            app.use(key[0] === '/' ? key : '/' + key, route);
-          });
-        });
-      }
-
-      // error handler
-      app.use(middleware.error(app));
+  // pre-authentication
+  if (options.preAuthentication && _.isFunction(options.preAuthentication)) {
+    return options.preAuthentication(app);
+  } else if (options.preAuthentication && _.isArray(options.preAuthentication)) {
+    options.preAuthentication.forEach(function (fn) {
+      app.use(fn(app));
     });
+  }
+  app.use(middleware.jwt(app));
+
+  // post-authentication
+  if (options.postAuthentication && _.isFunction(options.postAuthentication)) {
+    return options.postAuthentication(app);
+  } else if (options.postAuthentication && _.isArray(options.postAuthentication)) {
+    options.postAuthentication.forEach(function (fn) {
+      app.use(fn(app));
+    });
+  }
+  // routers
+  if (options.routers) {
+    Object.keys(options.routers).forEach(function (key) {
+      var route = options.routers[key];
+      (_.isArray(route) ? route : [route]).forEach(function (route) {
+        app.use(key[0] === '/' ? key : '/' + key, route);
+      });
+    });
+  }
+
+  // error handler
+  app.use(middleware.error(app));
+
+  return app
 };

--- a/test/health.js
+++ b/test/health.js
@@ -1,15 +1,17 @@
 'use strict';
 
-var supertest = require('supertest'),
-  server = require('../server')();
+var httpMocks = require('node-mocks-http'),
+  should = require('should'),
+  middleware = require('../middleware/health');
 
 describe('health check', function () {
   it('should 204 on health route', function (done) {
-    server.then(function (server) {
-      supertest(server)
-        .get('/health')
-        .expect(204, done);
-    })
-    .catch(done);
+    var req = httpMocks.createRequest(),
+      res = httpMocks.createResponse();
+
+    middleware(req, res);
+
+    res.should.have.property('statusCode', 204);
+    done();
   });
 });

--- a/test_client.js
+++ b/test_client.js
@@ -2,7 +2,7 @@
 
 var util = require('util'),
   _ = require('lodash'),
-  supertest = require('supertest-promised'),
+  supertest = require('supertest-as-promised'),
   jwt = require('./jwt');
 
 function extractUserFromContext (context) {
@@ -27,31 +27,25 @@ module.exports = {
 
   serve: function (server, context) {
     var route = function (method, path) {
-        return server
-          .then(function (app) {
-            return supertest(app);
-          })
-          .then(function (app) {
-            app = app[method.toLowerCase()](path);
+      var app = supertest(server)
+      app = app[method.toLowerCase()](path);
 
-            if (context) {
-              app = app.set('Authorization', 'Bearer ' + generateToken(extractUserFromContext(context)));
-            }
+      if (context) {
+        app = app.set('Authorization', 'Bearer ' + generateToken(extractUserFromContext(context)));
+      }
 
-            return app;
-          });
-      },
-      retval = {
-        route: route
-      };
+      return app;
+     },
+     retval = {
+       route: route
+     };
 
-    ['get', 'post', 'patch', 'put', 'delete'].forEach(function (method) {
-      retval[method] = function () {
-        var args = Array.prototype.slice.call(arguments);
-        return route(method, util.format.apply(util, args));
-      };
-    });
-    return retval;
+   ['get', 'post', 'patch', 'put', 'delete'].forEach(function (method) {
+     retval[method] = function () {
+       var args = Array.prototype.slice.call(arguments);
+       return route(method, util.format.apply(util, args));
+     };
+   });
+   return retval;
   }
-
 };


### PR DESCRIPTION
This PR addresses some annoying behavior being encountered while building the records API on top of this library. Said behavior includes:

- Having to wrap test assertions in an awkward extra layer of promises due to server initializing itself asynchronously
- Potentially having multiple versions of Express floating around when microservice APIs built on top of this library also want to use features of Express such as routers

The changes made were not many but are probably consequential enough for a major version bump: remove the dependency on express  and push that dependency to consumers of this library, and initialize the server without such heavy use of promises to make writing tests more straightforward.

If anything is found to be suspect or additional changes are desired, please let me know.

Most changes were spawned from discussions between myself and @apechimp as records development begins to really kick off