### PR TITLE
Access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ describe('Microservice tests', () => {
 
 ## Authorization
 
-In order to avoid a `401 unauthorized` response, an authentication token should be present on each request.
+In order to avoid a `401 unauthorized` response, an authorization token should be present on each request.
 
 ##### access_token (query string)
 

--- a/README.md
+++ b/README.md
@@ -69,3 +69,30 @@ describe('Microservice tests', () => {
   )
 })
 ```
+
+## Authorization
+
+In order to avoid a `401 unauthorized` response, an authentication token should be present on each request.
+
+##### access_token (query string)
+
+You'll need this for native get requests that aren't capable of putting headers on the request. These will be traditional
+anchor tags:
+
+`<a href ="http://localhost:5015/download/csv?access_token=accesstoken">`
+
+##### bearer token (request header)
+
+The bearer token approach will be the most common. API calls will employ this strategy:
+
+```js
+var request = {
+  method: 'POST',
+  url: 'http://localhost:5015/api/call',
+  headers: {
+    'Authorization': 'Bearer accesstoken' // this is the important part
+  }
+};
+
+// send request
+```

--- a/middleware/jwt.js
+++ b/middleware/jwt.js
@@ -7,7 +7,8 @@ var BPromise = require('bluebird'),
 
 module.exports = function (app) {
   return function (req, res, next) {
-    var token = (req.get('authorization') || '').substring('Bearer '.length);
+    var token = (req.get('authorization') || '').substring('Bearer '.length) || req.query.access_token;
+
     req.encodedJwt = token;
 
     if (!token || !token.length) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanetix/microservice",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Wrapper for writing JWT-authenticated microservices for internal use within Lanetix.",
   "author": "Lanetix <engineering@lanetix.com> (https://github.com/lanetix/)",
   "homepage": "https://github.com/lanetix/node-lanetix-microservice/",


### PR DESCRIPTION
From [api](https://github.com/lanetix/api/blob/a54766f3f40605c55b3b8ef2267d4fa20d515341/middleware/bearer_token_auth.js#L12-L16)

### Use Case

Consider a download link (href) that you want to trigger as a get request. You won't have a header present in that case since it's not an API call.