### PR TITLE
Unset CORS origin option unless one is provided.

### DIFF
--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -25,7 +25,9 @@ module.exports = function (app) {
           : corsOrigin(origin, callback)
       }
     } else if (typeof corsOrigin !== 'string' || !isLanetix.test(corsOrigin)) {
-      corsConfig.origin = [isLanetix, corsOrigin];
+      corsConfig.origin = corsOrigin === '*'
+        ? corsOrigin
+        : [isLanetix, corsOrigin];
     }
   }
 

--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var cors = require('cors'),
+  isLanetix = /\.lanetix\.com$/i,
   defaultExposedHeaders = [
     'X-Total-Count'
   ],
   corsConfig = {
-    origin: /\.lanetix\.com$/i,
     credentials: true,
     maxAge: 10 * 60 // this is the maximum we can cache in chrome
   };
@@ -17,9 +17,15 @@ module.exports = function (app) {
   // specify allowed origins
   if (corsOrigin) {
     if (Array.isArray(corsOrigin)) {
-      corsConfig.origin = corsOrigin.concat([corsConfig.origin]); // don't mutate
-    } else if (typeof corsOrigin !== 'string' || !corsConfig.origin.test(corsOrigin)) {
-      corsConfig.origin = [corsOrigin, corsConfig.origin];
+      corsConfig.origin = [isLanetix].concat(corsOrigin);
+    } else if (typeof corsOrigin === 'function') {
+      corsConfig.origin = function (origin, callback) {
+        return isLanetix.test(origin)
+          ? callback(null, true)
+          : corsOrigin(origin, callback)
+      }
+    } else if (typeof corsOrigin !== 'string' || !isLanetix.test(corsOrigin)) {
+      corsConfig.origin = [isLanetix, corsOrigin];
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanetix/microservice",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Wrapper for writing JWT-authenticated microservices for internal use within Lanetix.",
   "author": "Lanetix <engineering@lanetix.com> (https://github.com/lanetix/)",
   "homepage": "https://github.com/lanetix/node-lanetix-microservice/",
@@ -22,7 +22,7 @@
     "body-parser": "^1.9.2",
     "boom": "^2.6.0",
     "cookie-parser": "^1.3.5",
-    "cors": "^2.5.2",
+    "cors": "^2.7.1",
     "express-boom": "^0.3.0",
     "jsonwebtoken": "^5.0.0",
     "lodash": "^2.4.1",


### PR DESCRIPTION
The CORS module will [default to `*` when the origin option is not set](https://github.com/expressjs/cors/blob/ddc7d03e12db8e74d44b73aa6136b90b2bd25640/lib/index.js#L39-L44). And using v2.2.0 locally will break because your localhost services don't match the `isLanetix` regular expression.